### PR TITLE
Some refactorings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,13 @@
 
 GOPATH := `pwd`/vendor:$(GOPATH)
 BINARY := external-link-tracker
+BUILDFILES := main.go handlers.go
 
 build:
-	GOPATH=$(GOPATH) go build -o $(BINARY) main.go
+	GOPATH=$(GOPATH) go build -o $(BINARY) $(BUILDFILES)
 
 run:
-	GOPATH=$(GOPATH) go run main.go
+	GOPATH=$(GOPATH) go run $(BUILDFILES)
 
 test:
 	LINK_TRACKER_MONGO_DB=external_link_tracker_test GOPATH=$(GOPATH) go test

--- a/handlers.go
+++ b/handlers.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"net/http"
+	"net/url"
+	"time"
+
+	"labix.org/v2/mgo"
+	"labix.org/v2/mgo/bson"
+)
+
+var (
+	mgoSession      *mgo.Session
+	mgoDatabaseName = getenvDefault("LINK_TRACKER_MONGO_DB", "external_link_tracker")
+	mgoURL          = getenvDefault("LINK_TRACKER_MONGO_URL", "localhost")
+)
+
+// Store function in a variable so it can be overridden in the tests.
+var now = time.Now
+
+func getMgoSession() *mgo.Session {
+	if mgoSession == nil {
+		var err error
+		mgoSession, err = mgo.Dial(mgoURL)
+		if err != nil {
+			panic(err) // no, not really
+		}
+	}
+	return mgoSession.Clone()
+}
+
+type ExternalLink struct {
+	ExternalURL string `bson:"external_url"`
+}
+
+type ExternalLinkHit struct {
+	ExternalURL string    `bson:"external_url"`
+	DateTime    time.Time `bson:"date_time"`
+}
+
+// countHitOnURL logs a request time against the passed in URL
+func countHitOnURL(url string, timeOfHit time.Time) {
+	session := getMgoSession()
+	defer session.Close()
+	session.SetMode(mgo.Strong, true)
+
+	collection := session.DB(mgoDatabaseName).C("hits")
+
+	err := collection.Insert(&ExternalLinkHit{
+		ExternalURL: url,
+		DateTime:    timeOfHit,
+	})
+
+	if err != nil {
+		panic(err)
+	}
+}
+
+// ExternalLinkTrackerHandler looks up the `url` against a database whitelist,
+// and if it exists redirects to that URL while logging the request in the
+// background. It will 404 if the whitelist doesn't pass.
+func ExternalLinkTrackerHandler(w http.ResponseWriter, req *http.Request) {
+	session := getMgoSession()
+	defer session.Close()
+	session.SetMode(mgo.Monotonic, true)
+
+	collection := session.DB(mgoDatabaseName).C("links")
+
+	externalURL := req.URL.Query().Get("url")
+
+	err := collection.Find(bson.M{"external_url": externalURL}).One(&ExternalLink{})
+
+	if err != nil {
+		if err.Error() == "not found" {
+			http.NotFound(w, req)
+
+		} else {
+			panic(err)
+		}
+	} else {
+		go countHitOnURL(externalURL, now().UTC())
+
+		// Make sure this redirect is never cached
+		w.Header().Set("Cache-control", "no-cache, no-store, must-revalidate")
+		w.Header().Set("Pragma", "no-cache")
+		w.Header().Set("Expires", "0")
+		// Explicit 302 because this is a redirection proxy
+		http.Redirect(w, req, externalURL, http.StatusFound)
+	}
+}
+
+func saveExternalURL(url string) error {
+	session := getMgoSession()
+	defer session.Close()
+	session.SetMode(mgo.Strong, true)
+
+	collection := session.DB(mgoDatabaseName).C("links")
+
+	err := collection.Find(bson.M{"external_url": url}).One(&ExternalLink{})
+
+	if err != nil {
+		if err.Error() != "not found" {
+			return err
+		}
+		err1 := collection.Insert(&ExternalLink{
+			ExternalURL: url,
+		})
+
+		if err1 != nil {
+			return err1
+		}
+	}
+	return nil
+}
+
+// AddExternalUrl allows an external URL to be added to the database
+func AddExternalURL(w http.ResponseWriter, req *http.Request) (int, string) {
+	externalURL := req.URL.Query().Get("url")
+
+	if externalURL == "" {
+		return http.StatusBadRequest, "URL is required"
+	}
+
+	parsedURL, err := url.Parse(externalURL)
+
+	if err != nil {
+		panic(err)
+	}
+
+	if !parsedURL.IsAbs() {
+		return http.StatusBadRequest, "URL is not absolute"
+	}
+
+	err1 := saveExternalURL(externalURL)
+
+	if err1 != nil {
+		panic(err1)
+	}
+
+	return http.StatusCreated, "OK"
+}

--- a/main.go
+++ b/main.go
@@ -3,149 +3,17 @@ package main
 import (
 	"log"
 	"net/http"
-	"net/url"
 	"os"
-	"time"
 
 	"github.com/codegangsta/martini"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
 )
 
 var dontQuit = make(chan int)
 
 var (
-	mgoSession      *mgo.Session
 	pubAddr         = getenvDefault("LINK_TRACKER_PUBADDR", ":8080")
 	apiAddr         = getenvDefault("LINK_TRACKER_APIADDR", ":8081")
-	mgoDatabaseName = getenvDefault("LINK_TRACKER_MONGO_DB", "external_link_tracker")
-	mgoURL          = getenvDefault("LINK_TRACKER_MONGO_URL", "localhost")
 )
-
-// Store function in a variable so it can be overridden in the tests.
-var now = time.Now
-
-func getMgoSession() *mgo.Session {
-	if mgoSession == nil {
-		var err error
-		mgoSession, err = mgo.Dial(mgoURL)
-		if err != nil {
-			panic(err) // no, not really
-		}
-	}
-	return mgoSession.Clone()
-}
-
-type ExternalLink struct {
-	ExternalURL string `bson:"external_url"`
-}
-
-type ExternalLinkHit struct {
-	ExternalURL string    `bson:"external_url"`
-	DateTime    time.Time `bson:"date_time"`
-}
-
-// countHitOnURL logs a request time against the passed in URL
-func countHitOnURL(url string, timeOfHit time.Time) {
-	session := getMgoSession()
-	defer session.Close()
-	session.SetMode(mgo.Strong, true)
-
-	collection := session.DB(mgoDatabaseName).C("hits")
-
-	err := collection.Insert(&ExternalLinkHit{
-		ExternalURL: url,
-		DateTime:    timeOfHit,
-	})
-
-	if err != nil {
-		panic(err)
-	}
-}
-
-// ExternalLinkTrackerHandler looks up the `url` against a database whitelist,
-// and if it exists redirects to that URL while logging the request in the
-// background. It will 404 if the whitelist doesn't pass.
-func ExternalLinkTrackerHandler(w http.ResponseWriter, req *http.Request) {
-	session := getMgoSession()
-	defer session.Close()
-	session.SetMode(mgo.Monotonic, true)
-
-	collection := session.DB(mgoDatabaseName).C("links")
-
-	externalURL := req.URL.Query().Get("url")
-
-	err := collection.Find(bson.M{"external_url": externalURL}).One(&ExternalLink{})
-
-	if err != nil {
-		if err.Error() == "not found" {
-			http.NotFound(w, req)
-
-		} else {
-			panic(err)
-		}
-	} else {
-		go countHitOnURL(externalURL, now().UTC())
-
-		// Make sure this redirect is never cached
-		w.Header().Set("Cache-control", "no-cache, no-store, must-revalidate")
-		w.Header().Set("Pragma", "no-cache")
-		w.Header().Set("Expires", "0")
-		// Explicit 302 because this is a redirection proxy
-		http.Redirect(w, req, externalURL, http.StatusFound)
-	}
-}
-
-func saveExternalURL(url string) error {
-	session := getMgoSession()
-	defer session.Close()
-	session.SetMode(mgo.Strong, true)
-
-	collection := session.DB(mgoDatabaseName).C("links")
-
-	err := collection.Find(bson.M{"external_url": url}).One(&ExternalLink{})
-
-	if err != nil {
-		if err.Error() != "not found" {
-			return err
-		}
-		err1 := collection.Insert(&ExternalLink{
-			ExternalURL: url,
-		})
-
-		if err1 != nil {
-			return err1
-		}
-	}
-	return nil
-}
-
-// AddExternalUrl allows an external URL to be added to the database
-func AddExternalURL(w http.ResponseWriter, req *http.Request) (int, string) {
-	externalURL := req.URL.Query().Get("url")
-
-	if externalURL == "" {
-		return http.StatusBadRequest, "URL is required"
-	}
-
-	parsedURL, err := url.Parse(externalURL)
-
-	if err != nil {
-		panic(err)
-	}
-
-	if !parsedURL.IsAbs() {
-		return http.StatusBadRequest, "URL is not absolute"
-	}
-
-	err1 := saveExternalURL(externalURL)
-
-	if err1 != nil {
-		panic(err1)
-	}
-
-	return http.StatusCreated, "OK"
-}
 
 func getenvDefault(key string, defaultVal string) string {
 	val := os.Getenv(key)

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"github.com/codegangsta/martini"
 )
 
-var dontQuit = make(chan int)
 
 var (
 	pubAddr         = getenvDefault("LINK_TRACKER_PUBADDR", ":8080")
@@ -43,5 +42,6 @@ func main() {
 	go catchListenAndServe(apiAddr, mApi)
 	log.Println("external-link-tracker: listening for writes on " + apiAddr)
 
+	dontQuit := make(chan int)
 	<-dontQuit
 }


### PR DESCRIPTION
Split all the application logic into a separate file so that `main.go` is only concerned with starting up the application - listening on addresses, setting up http serving.

I'm planning to introduce changes to allow zero-downtime restarts, and this will add to the amount of logic in main, hence wanting to split out what can be.
