### PR TITLE
Add a healthcheck path handler

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -139,3 +139,7 @@ func AddExternalURL(w http.ResponseWriter, req *http.Request) (int, string) {
 
 	return http.StatusCreated, "OK"
 }
+
+func healthcheck(w http.ResponseWriter, req *http.Request) (int, string) {
+	return http.StatusOK, "OK"
+}

--- a/main.go
+++ b/main.go
@@ -8,10 +8,9 @@ import (
 	"github.com/codegangsta/martini"
 )
 
-
 var (
-	pubAddr         = getenvDefault("LINK_TRACKER_PUBADDR", ":8080")
-	apiAddr         = getenvDefault("LINK_TRACKER_APIADDR", ":8081")
+	pubAddr = getenvDefault("LINK_TRACKER_PUBADDR", ":8080")
+	apiAddr = getenvDefault("LINK_TRACKER_APIADDR", ":8081")
 )
 
 func getenvDefault(key string, defaultVal string) string {

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ func main() {
 	m.Get("/g", ExternalLinkTrackerHandler)
 	mApi := martini.Classic()
 	mApi.Put("/url", AddExternalURL)
+	mApi.Get("/healthcheck", healthcheck)
 
 	go catchListenAndServe(pubAddr, m)
 	log.Println("external-link-tracker: listening for redirects on " + pubAddr)

--- a/main_test.go
+++ b/main_test.go
@@ -210,3 +210,16 @@ func TestAPIGoodURLIsSaved(t *testing.T) {
 		t.Fatalf("Inserted wrong value, %v", result.ExternalURL)
 	}
 }
+
+func TestHealthcheckWorks(t *testing.T) {
+	request, _ := http.NewRequest("GET", "/healthcheck", nil)
+	response := httptest.NewRecorder()
+
+	m := martini.Classic()
+	m.Get("/healthcheck", healthcheck)
+	m.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("Got status %v, expected %v", response.Code, http.StatusOK)
+	}
+}


### PR DESCRIPTION
So we can monitor the status of the service using Nagios or similar, I've added a `/healthcheck` handler that responds on the API URL.
