### PR TITLE
Use empty struct for channel

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,6 +42,6 @@ func main() {
 	go catchListenAndServe(apiAddr, mApi)
 	log.Println("external-link-tracker: listening for writes on " + apiAddr)
 
-	dontQuit := make(chan int)
+	dontQuit := make(chan struct{})
 	<-dontQuit
 }


### PR DESCRIPTION
Channels that are being used purely for signalling should use an
empty struct rather than boolean or int types.

Using an empty struct declares that we're not interested in the value
sent or received; only in its closed property.

See http://talks.golang.org/2012/10things.slide#11
