### PR TITLE
Remove Martini framework

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -1,4 +1,2 @@
 gom 'github.com/alext/tablecloth', :commit => 'b373a9a'
-gom 'github.com/codegangsta/inject', :commit => '9aea7a2'
-gom 'github.com/codegangsta/martini', :commit => '06dc3e9'
 gom 'labix.org/v2/mgo', :commit => '245'

--- a/handlers.go
+++ b/handlers.go
@@ -64,6 +64,12 @@ func countHitOnURL(url string, timeOfHit time.Time, referrer string) {
 // and if it exists redirects to that URL while logging the request in the
 // background. It will 404 if the whitelist doesn't pass.
 func ExternalLinkTrackerHandler(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "GET" {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		w.Header().Set("Allow", "GET")
+		return
+	}
+
 	session := getMgoSession()
 	defer session.Close()
 	session.SetMode(mgo.Monotonic, true)
@@ -119,6 +125,12 @@ func saveExternalURL(url string) error {
 
 // AddExternalUrl allows an external URL to be added to the database
 func AddExternalURL(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "PUT" {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		w.Header().Set("Allow", "PUT")
+		return
+	}
+
 	externalURL := req.URL.Query().Get("url")
 
 	if externalURL == "" {
@@ -148,5 +160,11 @@ func AddExternalURL(w http.ResponseWriter, req *http.Request) {
 }
 
 func healthcheck(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "GET" {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		w.Header().Set("Allow", "GET")
+		return
+	}
+
 	fmt.Fprintln(w, "OK")
 }

--- a/handlers.go
+++ b/handlers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"time"
@@ -117,11 +118,12 @@ func saveExternalURL(url string) error {
 }
 
 // AddExternalUrl allows an external URL to be added to the database
-func AddExternalURL(w http.ResponseWriter, req *http.Request) (int, string) {
+func AddExternalURL(w http.ResponseWriter, req *http.Request) {
 	externalURL := req.URL.Query().Get("url")
 
 	if externalURL == "" {
-		return http.StatusBadRequest, "URL is required"
+		http.Error(w, "URL is required", http.StatusBadRequest)
+		return
 	}
 
 	parsedURL, err := url.Parse(externalURL)
@@ -131,7 +133,8 @@ func AddExternalURL(w http.ResponseWriter, req *http.Request) (int, string) {
 	}
 
 	if !parsedURL.IsAbs() {
-		return http.StatusBadRequest, "URL is not absolute"
+		http.Error(w, "URL is not absolute", http.StatusBadRequest)
+		return
 	}
 
 	err1 := saveExternalURL(externalURL)
@@ -140,9 +143,10 @@ func AddExternalURL(w http.ResponseWriter, req *http.Request) (int, string) {
 		panic(err1)
 	}
 
-	return http.StatusCreated, "OK"
+	w.WriteHeader(http.StatusCreated)
+	fmt.Fprintln(w, "OK")
 }
 
-func healthcheck(w http.ResponseWriter, req *http.Request) (int, string) {
-	return http.StatusOK, "OK"
+func healthcheck(w http.ResponseWriter, req *http.Request) {
+	fmt.Fprintln(w, "OK")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -140,6 +140,17 @@ func TestHitsAreLogged(t *testing.T) {
 
 }
 
+func TestExternalLinkTrackerHandlerOnlyAcceptsGET(t *testing.T) {
+	request, _ := http.NewRequest("PUT", "/g", nil)
+	response := httptest.NewRecorder()
+
+	ExternalLinkTrackerHandler(response, request)
+
+	if response.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("Got status %v, expected %v", response.Code, http.StatusMethodNotAllowed)
+	}
+}
+
 func TestAPINoURLReturns400(t *testing.T) {
 	request, _ := http.NewRequest("PUT", "/url", nil)
 	response := httptest.NewRecorder()
@@ -208,6 +219,17 @@ func TestAPIGoodURLIsSaved(t *testing.T) {
 	}
 }
 
+func TestAddExternalURLOnlyAcceptsPUT(t *testing.T) {
+	request, _ := http.NewRequest("GET", "/url", nil)
+	response := httptest.NewRecorder()
+
+	AddExternalURL(response, request)
+
+	if response.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("Got status %v, expected %v", response.Code, http.StatusMethodNotAllowed)
+	}
+}
+
 func TestHealthcheckWorks(t *testing.T) {
 	request, _ := http.NewRequest("GET", "/healthcheck", nil)
 	response := httptest.NewRecorder()
@@ -216,6 +238,17 @@ func TestHealthcheckWorks(t *testing.T) {
 
 	if response.Code != http.StatusOK {
 		t.Fatalf("Got status %v, expected %v", response.Code, http.StatusOK)
+	}
+}
+
+func TestHealthcheckOnlyAcceptsGET(t *testing.T) {
+	request, _ := http.NewRequest("PUT", "/healthcheck", nil)
+	response := httptest.NewRecorder()
+
+	healthcheck(response, request)
+
+	if response.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("Got status %v, expected %v", response.Code, http.StatusMethodNotAllowed)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codegangsta/martini"
 	"labix.org/v2/mgo"
 	"labix.org/v2/mgo/bson"
 )
@@ -145,9 +144,7 @@ func TestAPINoURLReturns400(t *testing.T) {
 	request, _ := http.NewRequest("PUT", "/url", nil)
 	response := httptest.NewRecorder()
 
-	m := martini.Classic()
-	m.Put("/url", AddExternalURL)
-	m.ServeHTTP(response, request)
+	AddExternalURL(response, request)
 
 	if response.Code != http.StatusBadRequest {
 		t.Fatalf("Got status %v, expected %v", response.Code, http.StatusBadRequest)
@@ -159,9 +156,7 @@ func TestAPIBadURLReturns400(t *testing.T) {
 	request, _ := http.NewRequest("PUT", "/url?url="+queryParam, nil)
 	response := httptest.NewRecorder()
 
-	m := martini.Classic()
-	m.Put("/url", AddExternalURL)
-	m.ServeHTTP(response, request)
+	AddExternalURL(response, request)
 
 	if response.Code != http.StatusBadRequest {
 		t.Fatalf("Got status %v, expected %v", response.Code, http.StatusBadRequest)
@@ -176,9 +171,7 @@ func TestAPIGoodURLReturns201(t *testing.T) {
 	request, _ := http.NewRequest("PUT", "/url?url="+queryParam, nil)
 	response := httptest.NewRecorder()
 
-	m := martini.Classic()
-	m.Put("/url", AddExternalURL)
-	m.ServeHTTP(response, request)
+	AddExternalURL(response, request)
 
 	if response.Code != http.StatusCreated {
 		t.Fatalf("Got status %v, expected %v", response.Code, http.StatusCreated)
@@ -194,9 +187,7 @@ func TestAPIGoodURLIsSaved(t *testing.T) {
 	request, _ := http.NewRequest("PUT", "/url?url="+queryParam, nil)
 	response := httptest.NewRecorder()
 
-	m := martini.Classic()
-	m.Put("/url", AddExternalURL)
-	m.ServeHTTP(response, request)
+	AddExternalURL(response, request)
 
 	collection := mgoSession.DB(mgoDatabaseName).C("links")
 
@@ -221,9 +212,7 @@ func TestHealthcheckWorks(t *testing.T) {
 	request, _ := http.NewRequest("GET", "/healthcheck", nil)
 	response := httptest.NewRecorder()
 
-	m := martini.Classic()
-	m.Get("/healthcheck", healthcheck)
-	m.ServeHTTP(response, request)
+	healthcheck(response, request)
 
 	if response.Code != http.StatusOK {
 		t.Fatalf("Got status %v, expected %v", response.Code, http.StatusOK)


### PR DESCRIPTION
Removes the Martini framework and replaces it with standard `net/http` constructs. This makes the code easier to follow and removes dependencies.

This means there's a bit more code, but given how simple and few the endpoints are I don't think we really lose much readability.
