### PR TITLE
Remove hardcoded collection name in test

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -34,7 +34,7 @@ func TestNoRecordReturns404(t *testing.T) {
 
 func TestExistingURLIsRedirected(t *testing.T) {
 	mgoSession := connectToMongo(t)
-	defer mgoSession.DB("external_link_tracker_test").DropDatabase()
+	defer mgoSession.DB(mgoDatabaseName).DropDatabase()
 
 	externalURL := "http://1.example.com"
 


### PR DESCRIPTION
This is unlikely to have actually affected anyone as the test Makefile
task uses the same name in its settings, but worth making sure the code
is clean.
