### PR TITLE
Auto-expire hits collection

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -4,33 +4,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"sync"
 	"time"
 
 	"labix.org/v2/mgo"
 	"labix.org/v2/mgo/bson"
 )
 
-var (
-	mgoSession      *mgo.Session
-	mgoSessionOnce  sync.Once
-	mgoDatabaseName = getenvDefault("LINK_TRACKER_MONGO_DB", "external_link_tracker")
-	mgoURL          = getenvDefault("LINK_TRACKER_MONGO_URL", "localhost")
-)
-
-// Store function in a variable so it can be overridden in the tests.
+// store function in a variable so it can be overridden in the tests.
 var now = time.Now
-
-func getMgoSession() *mgo.Session {
-	mgoSessionOnce.Do(func() {
-		var err error
-		mgoSession, err = mgo.Dial(mgoURL)
-		if err != nil {
-			panic(err) // no, not really
-		}
-	})
-	return mgoSession.Clone()
-}
 
 type ExternalLink struct {
 	ExternalURL string `bson:"external_url"`

--- a/main.go
+++ b/main.go
@@ -7,11 +7,7 @@ import (
 	"sync"
 
 	"github.com/alext/tablecloth"
-)
-
-var (
-	pubAddr = getenvDefault("LINK_TRACKER_PUBADDR", ":8080")
-	apiAddr = getenvDefault("LINK_TRACKER_APIADDR", ":8081")
+	"labix.org/v2/mgo"
 )
 
 func getenvDefault(key string, defaultVal string) string {
@@ -21,6 +17,26 @@ func getenvDefault(key string, defaultVal string) string {
 	}
 
 	return val
+}
+
+var (
+	pubAddr         = getenvDefault("LINK_TRACKER_PUBADDR", ":8080")
+	apiAddr         = getenvDefault("LINK_TRACKER_APIADDR", ":8081")
+	mgoSession      *mgo.Session
+	mgoSessionOnce  sync.Once
+	mgoDatabaseName = getenvDefault("LINK_TRACKER_MONGO_DB", "external_link_tracker")
+	mgoURL          = getenvDefault("LINK_TRACKER_MONGO_URL", "localhost")
+)
+
+func getMgoSession() *mgo.Session {
+	mgoSessionOnce.Do(func() {
+		var err error
+		mgoSession, err = mgo.Dial(mgoURL)
+		if err != nil {
+			panic(err) // no, not really
+		}
+	})
+	return mgoSession.Clone()
 }
 
 func catchListenAndServe(addr string, handler http.Handler, ident string, wg *sync.WaitGroup) {


### PR DESCRIPTION
Currently the `hits` collection is enormous (several GB) in production.

We aren't doing anything with this data and we won't be retroactively doing anything with it as it'll eventually be pushed somewhere else, so cap the data's age at a week using an [expiring index](http://docs.mongodb.org/manual/tutorial/expire-data/).

Also includes some refactoring, so might be worth going through it commit by commit (there's only 2 of them).
