### PR TITLE
Create the expiring index in the background

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ func main() {
 	index := mgo.Index{
 		Key:         []string{"date_time"},
 		ExpireAfter: 24 * time.Hour * 7, // expire after a week
+		Background:  true,
 	}
 	database.C("hits").EnsureIndex(index)
 


### PR DESCRIPTION
By default creating an index blocks all reads and writes to the database. We don't want to block all Mongo reads in the publishing systems (this caused an outage on preview for 10 minutes) so we should [make the index in the background](http://docs.mongodb.org/manual/tutorial/build-indexes-in-the-background/).
